### PR TITLE
Allow Pasting to Github gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ omf install dpaste
 
 ## Usage
 
-Basice usage:
+### Basic usage to pastebin:
 
 ```fish
 $ dpaste "I <3 to paste"
@@ -32,6 +32,21 @@ https://dpaste.de/ID2
 $ cat README.md | dpaste -t month
 https://dpaste.de/ID3
 ```
+
+### Github Gist Usage
+
+```fish
+$ dpaste gist -d "Your description" a.fish
+```
+
+#### Private gist
+```fish
+$ dpaste gist -d "Your description" -p my-file.fish
+```
+
+Params:
+- `-d or --desc ` Description of the gist, default "uploaded from dpaste"
+- `-p or --private ` Private gist, default public
 
 For more information see:
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,20 @@ $ cat README.md | dpaste -t month
 https://dpaste.de/ID3
 ```
 
-### Github Gist Usage
+### GitHub Gist Usage
 
 ```fish
-$ dpaste gist -d "Your description" a.fish
+$ dpaste -gist -d "Your description" a.fish
 ```
 
 #### Private gist
 ```fish
-$ dpaste gist -d "Your description" -p my-file.fish
+$ dpaste -gist -d "Your description" -p my-file.fish
 ```
 
 Params:
-- `-d or --desc ` Description of the gist, default "uploaded from dpaste"
+- `-g --gist` Create a GitHub gist
+- `-d or --desc ` Description of the gist, default "uploaded from dpaste fish shell plugin"
 - `-p or --private ` Private gist, default public
 
 For more information see:

--- a/functions/__dpaste_auth.fish
+++ b/functions/__dpaste_auth.fish
@@ -1,0 +1,6 @@
+function __dpaste_auth
+  read -P "Enter your Github Username : " -l username
+  read -s -P "Enter your Github Password : "  -l password
+  set -l auth (echo -n "$username:$password" | base64)
+  echo "Basic $auth"
+end

--- a/functions/__dpaste_auth.fish
+++ b/functions/__dpaste_auth.fish
@@ -1,6 +1,6 @@
 function __dpaste_auth
-  read -P "Enter your Github Username : " -l username
-  read -s -P "Enter your Github Password : "  -l password
+  read -P "Enter your GitHub Username : " -l username
+  read -s -P "Enter your GitHub Password : "  -l password
   set -l auth (echo -n "$username:$password" | base64)
   echo "Basic $auth"
 end

--- a/functions/__dpaste_gist.fish
+++ b/functions/__dpaste_gist.fish
@@ -1,0 +1,23 @@
+function __dpaste_gist
+  set -l __gist_desc "uploaded from dpaste fish shell plugin"
+  set -l __gist_public true
+  set -l __gist_file_name ""
+
+  argu d: desc: g gist p public  -- $argv | while read -l opt value
+  switch $opt
+    case -d --desc
+      set __gist_desc $value
+    case -p --private
+      set __gist_public false
+    case -g --gist
+    case _
+      set __gist_file_name $value
+    end
+  end
+  
+  if test -e $__gist_file_name
+    __dpaste_send_gist $__gist_desc $__gist_file_name $__gist_public
+  else
+    echo "File does not exist"
+  end
+end

--- a/functions/__dpaste_help.fish
+++ b/functions/__dpaste_help.fish
@@ -6,9 +6,17 @@ function __dpaste_help
   dpaste -t onetime < README.md
   cat README.md | dpaste -t month
   dpaste  # Starts interactive mode
-
+  
 Options:
   -t --time EXPIRES  set snippet expiration time: $__dpaste_expires_choises [default: month]
+
+Github Gist:
+  dpaste --gist -d \"Your description\" a.fish
+  dpaste --gist -d \"Your description\" -p my-file.fish
+
+  -g --gist Create a Github gist
+  -p --private Create a private gist
+  -d --desc Description of the gist
 
 Configuration:
   You can use this plugin with other dpaste instances.
@@ -19,5 +27,8 @@ Configuration:
 
   You can even use this plugin with sprunge.us.
   Note, that sprunge.us doesn't support '-t' option.
-    set dpaste_site 'sprunge.us'"
+    set dpaste_site 'sprunge.us'
+
+  You can configure it to use Github Gist always
+    set dpaste_site 'gist.github.com'"
 end

--- a/functions/__dpaste_help.fish
+++ b/functions/__dpaste_help.fish
@@ -6,15 +6,15 @@ function __dpaste_help
   dpaste -t onetime < README.md
   cat README.md | dpaste -t month
   dpaste  # Starts interactive mode
-  
+
 Options:
   -t --time EXPIRES  set snippet expiration time: $__dpaste_expires_choises [default: month]
 
-Github Gist:
+GitHub Gist:
   dpaste --gist -d \"Your description\" a.fish
   dpaste --gist -d \"Your description\" -p my-file.fish
 
-  -g --gist Create a Github gist
+  -g --gist Create a GitHub gist
   -p --private Create a private gist
   -d --desc Description of the gist
 
@@ -29,6 +29,7 @@ Configuration:
   Note, that sprunge.us doesn't support '-t' option.
     set dpaste_site 'sprunge.us'
 
-  You can configure it to use Github Gist always
-    set dpaste_site 'gist.github.com'"
+  You can configure it to use GitHub Gist always
+    set dpaste_site 'gist.github.com'
+    Once this is set, you will not need to add the --gist flag"
 end

--- a/functions/__dpaste_pastebin.fish
+++ b/functions/__dpaste_pastebin.fish
@@ -1,0 +1,15 @@
+function __dpaste_pastebin
+  if isatty
+    if [ -n $argv ]
+      if [ -f $argv ]
+        cat $argv
+      else
+        echo $argv
+      end | __dpaste_send
+    else
+      __dpaste_help
+    end
+  else
+    __dpaste_send
+  end
+end

--- a/functions/__dpaste_send_gist.fish
+++ b/functions/__dpaste_send_gist.fish
@@ -1,0 +1,25 @@
+function __dpaste_send_gist
+  set -l __gist_desc $argv[1]
+  set -l __gist_file_name $argv[2]
+  set -l __gist_public $argv[3]
+  set -l __gist_file_content (cat $__gist_file_name | sed s/\"/\\\\\"/g)
+  set -l __gist_auth (__dpaste_auth)
+  set -l json "{
+        \"description\": \"$__gist_desc\",
+        \"public\": $__gist_public,
+        \"files\": {
+          \"$__gist_file_name\": { \"content\": \"$__gist_file_content\" }
+        }
+      }"
+
+  curl --silent -X POST "$__dpaste_url_gist_github_com" \
+      -H "Authorization: $__gist_auth" \
+      -H "Content-Type: application/json" \
+      -d $json \
+  | grep -Eo '(?:"raw_url":\\s*")(.*?)(?:")' \
+  | grep -o '"[^"]*"$'
+  
+  if test $status -ne 0
+    echo "Some error occured"
+  end
+end

--- a/functions/dpaste.fish
+++ b/functions/dpaste.fish
@@ -1,19 +1,13 @@
 function dpaste
   __dpaste_parse_help $argv
   or begin
-    set argv (__dpaste_parse_expires $argv)
-    if isatty
-      if [ -n $argv ]
-        if [ -f $argv ]
-          cat $argv
-        else
-          echo $argv
-        end | __dpaste_send
-      else
-        __dpaste_help
-      end
+    if test $__dpaste_keyword = 'github'
+    or contains -- -g $argv
+    or contains -- --gist $argv
+      __dpaste_gist $argv
     else
-      __dpaste_send
+      set argv (__dpaste_parse_expires $argv)
+      __dpaste_pastebin $argv
     end
   end
 end

--- a/init.fish
+++ b/init.fish
@@ -3,6 +3,8 @@ set -g __dpaste_url_dpaste_de 'https://dpaste.de/api/'
 set -g __dpaste_keyword_dpaste_de 'content'
 set -g __dpaste_url_sprunge_us 'http://sprunge.us/'
 set -g __dpaste_keyword_sprunge_us 'sprunge'
+set -g __dpaste_url_gist_github_com 'https://api.github.com/gists'
+set -g __dpaste_keyword_gist_github_com 'github'
 
 set -q dpaste_site; or set -g dpaste_site 'dpaste.de'
 set suffix (echo $dpaste_site | sed "s/\./_/g")


### PR DESCRIPTION
Adding functionality to publish to Github gist

Changes made:
- `dpaste` for gists will be called as `dpaste gist` for backward comparability.
- Flag to create the gist as private
- Description is optional, the is a default description is `uploaded from dpaste`

Notes:
- As @rominf raised repo may continue with the same name to prevent breakage for existing users