### PR TITLE
fix: url update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <br/>
 
-Package allows to quickly share text on pastebin sites dpaste.de (and similar), sprunge.us.
+Package allows to quickly share text on pastebin sites dpaste.org (and similar), sprunge.us.
 
 ## Install
 
@@ -24,13 +24,13 @@ $ omf install dpaste
 
 ```fish
 $ dpaste "I <3 to paste"
-https://dpaste.de/ID0
+https://dpaste.org/ID0
 $ dpaste -t week README.md
-https://dpaste.de/ID1
+https://dpaste.org/ID1
 $ dpaste -t onetime < README.md
-https://dpaste.de/ID2
+https://dpaste.org/ID2
 $ cat README.md | dpaste -t month
-https://dpaste.de/ID3
+https://dpaste.org/ID3
 ```
 
 ### GitHub Gist Usage

--- a/conf.d/dpaste.fish
+++ b/conf.d/dpaste.fish
@@ -1,12 +1,12 @@
 set -g __dpaste_expires_choises '(onetime|1|twotimes|2|hour|week|month|never)'
-set -g __dpaste_url_dpaste_de 'https://dpaste.de/api/'
+set -g __dpaste_url_dpaste_de 'https://dpaste.org/api/'
 set -g __dpaste_keyword_dpaste_de 'content'
 set -g __dpaste_url_sprunge_us 'http://sprunge.us/'
 set -g __dpaste_keyword_sprunge_us 'sprunge'
 set -g __dpaste_url_gist_github_com 'https://api.github.com/gists'
 set -g __dpaste_keyword_gist_github_com 'github'
 
-set -q dpaste_site; or set -g dpaste_site 'dpaste.de'
+set -q dpaste_site; or set -g dpaste_site 'dpaste.org'
 set suffix (echo $dpaste_site | sed "s/\./_/g")
 
 set -g __dpaste_url_data 'format=url'

--- a/tests/test_dpaste.fish
+++ b/tests/test_dpaste.fish
@@ -43,28 +43,28 @@ end
 function suite_dpaste
 
   function setup
-    set dpaste_site 'dpaste.de'
+    set dpaste_site 'dpaste.org'
     __dpaste_set_defaults
   end
 
   function test_dpaste_parse_expires
     assert_equal text (__dpaste_parse_expires text)
-    assert_equal "https://dpaste.de/api/?format=url" $__dpaste_send_url
+    assert_equal "https://dpaste.org/api/?format=url" $__dpaste_send_url
   end
 
   function test_dpaste_parse_expires_1
     assert_equal text (__dpaste_parse_expires -t 1 text)
-    assert_equal "https://dpaste.de/api/?format=url&expires=onetime" $__dpaste_send_url
+    assert_equal "https://dpaste.org/api/?format=url&expires=onetime" $__dpaste_send_url
   end
 
   function test_dpaste_parse_expires_hour
     assert_equal text (__dpaste_parse_expires -t hour text)
-    assert_equal "https://dpaste.de/api/?format=url&expires=3600" $__dpaste_send_url
+    assert_equal "https://dpaste.org/api/?format=url&expires=3600" $__dpaste_send_url
   end
 
   function test_dpaste_parse_expires_never
     assert_equal text (__dpaste_parse_expires -t never text)
-    assert_equal "https://dpaste.de/api/?format=url&expires=never" $__dpaste_send_url
+    assert_equal "https://dpaste.org/api/?format=url&expires=never" $__dpaste_send_url
   end
 
   function test_dpaste_system_file_redirect


### PR DESCRIPTION
dpaste.de is now moved to dpaste.org. Therefore, sending a paste to dpaste.de is useless.

![Email from Martin](https://i.dpaste.org/GhovJonP/direct.png)